### PR TITLE
Fix/proxy

### DIFF
--- a/greygoosic/src/setupProxy.js
+++ b/greygoosic/src/setupProxy.js
@@ -1,11 +1,9 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
 const pkg = require("../package.json");
 const target = process.env.PROXY || pkg.proxy;
-
 module.exports = (app) =>
-  target &&
-  app.use((req, res, next) =>
-    req.accepts("text/html")
-      ? next()
-      : createProxyMiddleware({ target: target })(req, res, next)
+  app.use("/api",
+      createProxyMiddleware({ target: target,
+        changeOrigin: true
+      })
   );

--- a/greygoosic/src/setupProxy.js
+++ b/greygoosic/src/setupProxy.js
@@ -1,9 +1,12 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
 const pkg = require("../package.json");
 const target = process.env.PROXY || pkg.proxy;
-module.exports = (app) =>
-  app.use("/api",
-      createProxyMiddleware({ target: target,
-        changeOrigin: true
-      })
-  );
+module.exports = (app) => {
+  if (target) {
+    app.use("/api",
+        createProxyMiddleware({ target: target,
+          changeOrigin: true
+        })
+    );
+  }
+}


### PR DESCRIPTION
Proxy was not working when setting PROXY env variable. I made some modifications to setupProxy in order to make it work, based on the official docs https://create-react-app.dev/docs/proxying-api-requests-in-development/#configuring-the-proxy-manually ; I tested setting PROXY env, unsetting it and even removing proxy from package.json.